### PR TITLE
Replace build.bash with build.go and improve script

### DIFF
--- a/caddyman.sh
+++ b/caddyman.sh
@@ -26,6 +26,7 @@ declare -A plugins_urls=(
     ["prometheus"]="github.com/miekg/caddy-prometheus"
     ["cgi"]="github.com/jung-kurt/caddy-cgi"
     ["filemanager"]="github.com/hacdias/filemanager/caddy/filemanager"
+    ["iyofilemanager"]="github.com/itsyouonline/filemanager/caddy/filemanager"
     ["webdav"]="github.com/hacdias/caddy-webdav"
     ["jekyll"]="github.com/hacdias/filemanager/caddy/jekyll"
     ["hugo"]="github.com/hacdias/filemanager/caddy/hugo"
@@ -98,7 +99,7 @@ install_hugo(){
 
     echo -ne "Installing Hugo \r"
     go get github.com/gohugoio/hugo
-    go get -u  github.com/gohugoio/hugo
+    go get -u github.com/gohugoio/hugo
     echo -ne "Installing Hugo [SUCCESS]"
     echo ""
 }

--- a/caddyman.sh
+++ b/caddyman.sh
@@ -142,8 +142,12 @@ rebuild_caddy(){
     CADDY_PATH=$GOPATH/src/github.com/mholt/caddy
 
     cd $CADDY_PATH/caddy
+    echo -ne "Ensure caddy build system dependencies\r"
+    go get -v github.com/caddyserver/buildworker/cmd/buildworker
+    echo -ne "Ensure caddy build system dependencies [SUCCESS]\r"
+
     echo -ne "Rebuilding caddy binary\r"
-    bash build.bash
+    go run build.go
     echo -ne "Rebuilding caddy binary [SUCCESS]\r"
 
     if pgrep -x "caddy" > /dev/null

--- a/caddyman.sh
+++ b/caddyman.sh
@@ -125,12 +125,14 @@ update_caddy_plugin_imports_and_directives(){
 
     echo -ne 'Updating plugin imports in $CADDY_PATH/caddy/caddymain/run.go\r'
     sed -i "s%This is where other plugins get plugged in (imported)%This is where other plugins get plugged in (imported)\n_ \"$url\"%g" $MAIN_FILE
+    gofmt -w $MAIN_FILE
     echo -ne 'Updating plugin imports in $CADDY_PATH/caddy/caddymain/run.go [SUCCESS]\r'
     echo ""
 
     if [ ! $directive == "" ]; then
         echo -ne "Updating plugin directive in $PLUGINS_FILE\r"
         sed -i "/\"prometheus\",/a \"$directive\"," $PLUGINS_FILE
+        gofmt -w $MAIN_FILE
         echo -ne "Updating plugin directive in $PLUGINS_FILE [SUCCESS]\r"
         echo ""
     fi

--- a/caddyman.sh
+++ b/caddyman.sh
@@ -59,10 +59,9 @@ check_go_path(){
 # Update Caddy source
 update_caddy(){
     CADDY_GO_PACKAGE=github.com/mholt/caddy
-    echo -ne "Ensuring Caddy is up2date \r"
+    echo -ne "Ensuring Caddy is up-to-date \r"
     go get $CADDY_GO_PACKAGE
-    echo -n "Ensuring Caddy is up2date [SUCCESS]"
-    echo ""
+    echo "Ensuring Caddy is up-to-date [SUCCESS]"
 }
 
 
@@ -100,8 +99,7 @@ install_hugo(){
     echo -ne "Installing Hugo \r"
     go get github.com/gohugoio/hugo
     go get -u github.com/gohugoio/hugo
-    echo -ne "Installing Hugo [SUCCESS]"
-    echo ""
+    echo "Installing Hugo [SUCCESS]"
 }
 
 install_plugin(){
@@ -145,19 +143,18 @@ rebuild_caddy(){
     cd $CADDY_PATH/caddy
     echo -ne "Ensure caddy build system dependencies\r"
     go get -v github.com/caddyserver/buildworker/cmd/buildworker
-    echo -ne "Ensure caddy build system dependencies [SUCCESS]\r"
+    echo "Ensure caddy build system dependencies [SUCCESS]"
 
     echo -ne "Rebuilding caddy binary\r"
     go run build.go
-    echo -ne "Rebuilding caddy binary [SUCCESS]\r"
+    echo "Rebuilding caddy binary [SUCCESS]"
 
     if pgrep -x "caddy" > /dev/null
 
     then
-        echo -ne "Caddy is Rnning .. Stopping process\r"
+        echo -ne "Caddy is Running .. Stopping process\r"
         kill -9 `pgrep -x caddy` > /dev/null
-        echo -ne "Caddy is Rnning .. Stopping process [SUCCESS]\r"
-        echo ""
+        echo "Caddy is Running .. Stopping process [SUCCESS]"
     fi
 
     cp caddy /$GOPATH/bin


### PR DESCRIPTION
This pull request replace the `build.bash` used in Caddy with `build.go` since `build.bash` is not existing/supported anymore.

Moreover, this pull request add some specific internal filemanager on the list and improve a little bit some verbosity on the script.